### PR TITLE
Mobile glitch fix

### DIFF
--- a/style.css
+++ b/style.css
@@ -192,7 +192,7 @@ font-size: 4.0vw;
 }
 
 .bottom img  {
-max-width:400px;
+max-width:300px;
 height:auto;
 align-self:center;
 padding: 20px;
@@ -240,6 +240,13 @@ body{
 }
 
 
+@media only screen and (min-width: 800px) {
+
+.bottom img{
+
+  max-width:600px;
+  }
+}
 @media only screen and (min-width: 1500px) {
 .head{
     min-height: 100vh;
@@ -277,5 +284,9 @@ body{
     .bottom{
       font-size: 1.2vw;
 
+    }
+    .bottom img{
+
+    max-width:600px;
     }
 }


### PR DESCRIPTION
Max width of bottom div class .bottom img makes it so that on certain mobile devices the width exceeds the screen size.
Breaks everything unless u set it to desktop mode.
To fix this capped default size to 300px and added a media query so that it grows on desktop.